### PR TITLE
Pin nixpkgs in flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ URPS is distributed under the AGPL-3.0-only license.
 
     opam install urps
 
+## Building with Nix
+
+Set up Nix Flakes, then run:
+
+    nix build
+
+## Developing with Nix
+
+To get a development shell with all dependencies and build tools installed, run:
+
+    nix develop
+
 ## Building
 
 To build from source, generate documentation, and run tests, use `dune`:

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,18 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1625604429,
-        "narHash": "sha256-qnQTLukEtqV5XL77l72PeG2O697j8bou4TsCLt7EN7Y=",
+        "lastModified": 1629705759,
+        "narHash": "sha256-M5sHgjA1OZn/c21pk64qd5kjbkBpbZuYwgaDEl9kiP8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a2cfe3fb7ee689165a5dfc35b39bc16000c68082",
+        "rev": "5bc8b980b9178ef9a4bb622320cf34e59ea2ea10",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,8 @@
 {
   description = "URPS: Uniform Random Peer Sampler";
 
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
   outputs = { self, nixpkgs }:
     let
       supportedSystems = [


### PR DESCRIPTION
Guarantees reproducibility as the flake no longer relies on the registry-provided `nixpkgs`, which is either `master` or a user-pinned value which could break things.